### PR TITLE
Fix: sourceOffset & sourcePartition 로직 수정

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,8 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="f58cb33c-beba-45ab-8e56-d85df82c7855" name="변경" comment="">
+      <change beforePath="$PROJECT_DIR$/.idea/gradle.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/gradle.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceConfig.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceConfig.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceConnector.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceConnector.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceTask.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceTask.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -48,12 +51,40 @@
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
+  <component name="GitToolBoxStore">
+    <option name="recentBranches">
+      <RecentBranches>
+        <option name="branchesForRepo">
+          <list>
+            <RecentBranchesForRepo>
+              <option name="branches">
+                <list>
+                  <RecentBranch>
+                    <option name="branchName" value="develop" />
+                    <option name="lastUsedInstant" value="1716814534" />
+                  </RecentBranch>
+                  <RecentBranch>
+                    <option name="branchName" value="main" />
+                    <option name="lastUsedInstant" value="1716814533" />
+                  </RecentBranch>
+                </list>
+              </option>
+              <option name="repositoryRootUrl" value="file://$PROJECT_DIR$" />
+            </RecentBranchesForRepo>
+          </list>
+        </option>
+      </RecentBranches>
+    </option>
+  </component>
   <component name="MarkdownSettingsMigration">
     <option name="stateVersion" value="1" />
   </component>
   <component name="ProjectCodeStyleSettingsMigration">
     <option name="version" value="2" />
   </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 6
+}</component>
   <component name="ProjectId" id="2dDr4FHbXbFPTh3oBjYW3RL0SYz" />
   <component name="ProjectLevelVcsManager" settingsEditedManually="true" />
   <component name="ProjectViewState">
@@ -66,15 +97,24 @@
     &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
     &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
     &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
     &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
     &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
     &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
     &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
     &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;preferences.pluginManager&quot;,
     &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   }
 }</component>
+  <component name="SharedIndexes">
+    <attachedChunks>
+      <set>
+        <option value="bundled-jdk-9f38398b9061-39b83d9b5494-intellij.indexing.shared.core-IU-241.17011.79" />
+        <option value="bundled-js-predefined-1d06a55b98c1-0b3e54e931b4-JavaScript-IU-241.17011.79" />
+      </set>
+    </attachedChunks>
+  </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="애플리케이션 수준" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
     <task active="true" id="Default" summary="디폴트 작업">
@@ -84,6 +124,11 @@
       <option name="presentableId" value="Default" />
       <updated>1709553297432</updated>
       <workItem from="1709553298653" duration="33026000" />
+      <workItem from="1716814511591" duration="3872000" />
+      <workItem from="1717418248899" duration="394000" />
+      <workItem from="1717418687746" duration="318000" />
+      <workItem from="1717419161679" duration="128000" />
+      <workItem from="1717419298940" duration="4107000" />
     </task>
     <servers />
   </component>

--- a/src/main/java/com/github/hans/AWSCloudwatchLogSourceConfig.java
+++ b/src/main/java/com/github/hans/AWSCloudwatchLogSourceConfig.java
@@ -14,9 +14,8 @@ public class AWSCloudwatchLogSourceConfig extends AbstractConfig {
     private static final String AWS_CLOUDWATCH_LOG_GROUP_DOC = "Cloudwatch Log group Name";
     public static final String AWS_CLOUDWATCH_LOG_STREAM = "aws.cloudwatch.log.stream";
     private static final String AWS_CLOUDWATCH_LOG_STREAM_DOC = "Cloudwatch Log stream Name in aws.cloudwatch.log.group";
-    public static final String KAFKA_TOPIC = "topic.name";
-    private static final String KAFKA_TOPIC_DOC = "The name of the topic where you want to store the record";
-
+    public static final String START_FROM_LATEST = "start.from.latest";
+    private static final String START_FROM_LATEST_DOC = "Start from latest log stream";
 
 
     public AWSCloudwatchLogSourceConfig(Map<?, ?> originals) {
@@ -29,7 +28,7 @@ public class AWSCloudwatchLogSourceConfig extends AbstractConfig {
                 .define(AWS_REGION, ConfigDef.Type.STRING, ConfigDef.Importance.MEDIUM, AWS_REGION_DOC)
                 .define(AWS_CLOUDWATCH_LOG_GROUP, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, AWS_CLOUDWATCH_LOG_GROUP_DOC)
                 .define(AWS_CLOUDWATCH_LOG_STREAM, ConfigDef.Type.STRING, "",ConfigDef.Importance.LOW, AWS_CLOUDWATCH_LOG_STREAM_DOC)
-                .define(KAFKA_TOPIC, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, KAFKA_TOPIC_DOC);
+                .define(START_FROM_LATEST, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.LOW, START_FROM_LATEST_DOC);
     }
 
 }

--- a/src/main/java/com/github/hans/AWSCloudwatchLogSourceConnector.java
+++ b/src/main/java/com/github/hans/AWSCloudwatchLogSourceConnector.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.source.ExactlyOnceSupport;
 import org.apache.kafka.connect.source.SourceConnector;
 
 import java.util.ArrayList;
@@ -46,5 +47,11 @@ public class AWSCloudwatchLogSourceConnector extends SourceConnector {
     @Override
     public String version() {
         return AppInfoParser.getVersion();
+    }
+
+    @Override
+    public ExactlyOnceSupport exactlyOnceSupport(Map<String, String> props) {
+        // 로그 스트림을 설정하지 않더라도 Lastest 스트림을 지정하기 때문에 항상 exactly-once SUPPORTED 반환
+        return ExactlyOnceSupport.SUPPORTED;
     }
 }


### PR DESCRIPTION
AWSCloudwatchLogSourceConfig
- KAFKA_TOPIC 제거: Cloudwatch Log Group을 토픽명으로 활용하도록 변경
- START_FROM_LATEST(기본값 true): Log Stream 구성 설정 유연성 부여

AWSCloudwatchLogSourceTask
- SourcePartition: Log Stream명으로 변경
- SourceOffset: Log 타임스탬프로 변경

KAFKA_TOPIC을 제거하고, Log Group 사용을 강제하여, 오프셋 추적이 가능하도록 변경