### PR TITLE
Fix: log timestamp 기준으로 프로듀싱 하도록 로직 변경(logStream 옵션 삭제)

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,9 +5,10 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="f58cb33c-beba-45ab-8e56-d85df82c7855" name="변경" comment="">
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceConfig.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceConfig.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceConnector.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceConnector.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceTask.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/com/github/hans/AWSCloudwatchLogSourceTask.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -58,12 +59,12 @@
               <option name="branches">
                 <list>
                   <RecentBranch>
-                    <option name="branchName" value="develop" />
-                    <option name="lastUsedInstant" value="1716814534" />
+                    <option name="branchName" value="main" />
+                    <option name="lastUsedInstant" value="1717424336" />
                   </RecentBranch>
                   <RecentBranch>
-                    <option name="branchName" value="main" />
-                    <option name="lastUsedInstant" value="1716814533" />
+                    <option name="branchName" value="develop" />
+                    <option name="lastUsedInstant" value="1716814534" />
                   </RecentBranch>
                 </list>
               </option>
@@ -126,7 +127,8 @@
       <workItem from="1717418248899" duration="394000" />
       <workItem from="1717418687746" duration="318000" />
       <workItem from="1717419161679" duration="128000" />
-      <workItem from="1717419298940" duration="4855000" />
+      <workItem from="1717419298940" duration="6099000" />
+      <workItem from="1717740783930" duration="6556000" />
     </task>
     <servers />
   </component>

--- a/src/main/java/com/github/hans/AWSCloudwatchLogSourceConfig.java
+++ b/src/main/java/com/github/hans/AWSCloudwatchLogSourceConfig.java
@@ -12,10 +12,6 @@ public class AWSCloudwatchLogSourceConfig extends AbstractConfig {
     private static final String AWS_REGION_DOC = "AWS Profile region";
     public static final String AWS_CLOUDWATCH_LOG_GROUP = "aws.cloudwatch.log.group";
     private static final String AWS_CLOUDWATCH_LOG_GROUP_DOC = "Cloudwatch Log group Name";
-    public static final String AWS_CLOUDWATCH_LOG_STREAM = "aws.cloudwatch.log.stream";
-    private static final String AWS_CLOUDWATCH_LOG_STREAM_DOC = "Cloudwatch Log stream Name in aws.cloudwatch.log.group";
-    public static final String START_FROM_LATEST = "start.from.latest";
-    private static final String START_FROM_LATEST_DOC = "Start from latest log stream";
 
 
     public AWSCloudwatchLogSourceConfig(Map<?, ?> originals) {
@@ -26,9 +22,7 @@ public class AWSCloudwatchLogSourceConfig extends AbstractConfig {
     public static ConfigDef config() {
         return new ConfigDef()
                 .define(AWS_REGION, ConfigDef.Type.STRING, ConfigDef.Importance.MEDIUM, AWS_REGION_DOC)
-                .define(AWS_CLOUDWATCH_LOG_GROUP, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, AWS_CLOUDWATCH_LOG_GROUP_DOC)
-                .define(AWS_CLOUDWATCH_LOG_STREAM, ConfigDef.Type.STRING, "",ConfigDef.Importance.LOW, AWS_CLOUDWATCH_LOG_STREAM_DOC)
-                .define(START_FROM_LATEST, ConfigDef.Type.BOOLEAN, true, ConfigDef.Importance.LOW, START_FROM_LATEST_DOC);
+                .define(AWS_CLOUDWATCH_LOG_GROUP, ConfigDef.Type.STRING, ConfigDef.Importance.HIGH, AWS_CLOUDWATCH_LOG_GROUP_DOC);
     }
 
 }

--- a/src/main/java/com/github/hans/AWSCloudwatchLogSourceConnector.java
+++ b/src/main/java/com/github/hans/AWSCloudwatchLogSourceConnector.java
@@ -4,7 +4,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.connector.Task;
-import org.apache.kafka.connect.source.ExactlyOnceSupport;
 import org.apache.kafka.connect.source.SourceConnector;
 
 import java.util.ArrayList;
@@ -49,9 +48,4 @@ public class AWSCloudwatchLogSourceConnector extends SourceConnector {
         return AppInfoParser.getVersion();
     }
 
-    @Override
-    public ExactlyOnceSupport exactlyOnceSupport(Map<String, String> props) {
-        // 로그 스트림을 설정하지 않더라도 Lastest 스트림을 지정하기 때문에 항상 exactly-once SUPPORTED 반환
-        return ExactlyOnceSupport.SUPPORTED;
-    }
 }

--- a/src/main/java/com/github/hans/AWSCloudwatchLogSourceTask.java
+++ b/src/main/java/com/github/hans/AWSCloudwatchLogSourceTask.java
@@ -20,8 +20,7 @@ public class AWSCloudwatchLogSourceTask extends SourceTask {
     private CloudWatchLogsClient cloudWatchLogsClient;
     private AWSCloudwatchLogSourceConfig config;
     private String logGroup;
-    private String logStream;
-    private long lastEventTimestamp;
+    private String topicName;
 
     @Override
     public String version() {
@@ -34,13 +33,17 @@ public class AWSCloudwatchLogSourceTask extends SourceTask {
         try {
             config = new AWSCloudwatchLogSourceConfig(props);
             logGroup = config.getString(AWSCloudwatchLogSourceConfig.AWS_CLOUDWATCH_LOG_GROUP);
+            topicName = logGroup.replace("/","-").substring(1);
             initializeCloudWatchLogsClient();
-            setupLogStream();
+
         } catch (ConfigException e) {
             throw new ConfigException("Couldn't start AWSCloudwatchLogSourceTask due to configuration error", e);
         }
     }
 
+    /**
+     * AWS CloudWatchLogsClient 초기화
+     */
     private void initializeCloudWatchLogsClient() {
         try {
             Region awsRegion = Region.of(config.getString(AWSCloudwatchLogSourceConfig.AWS_REGION));
@@ -54,37 +57,15 @@ public class AWSCloudwatchLogSourceTask extends SourceTask {
         }
     }
 
-    /**
-     * aws.cloudwatch.log.group에서 설정한 logStream을 지정하는 메서드.
-     * start.from.latest 설정이 false일 경우 log stream을 필수로 설정해야 한다.
-     */
-    private void setupLogStream() {
-        try {
-            logStream = config.getString(AWSCloudwatchLogSourceConfig.AWS_CLOUDWATCH_LOG_STREAM);
-
-            if (!config.getBoolean(AWSCloudwatchLogSourceConfig.START_FROM_LATEST)) {
-                if (logStream.isEmpty()) {
-                    throw new ConfigException("aws.cloudwatch.log.stream must be specified when start.from.latest is false");
-                }
-            } else {
-                logStream = getLatestLogStream();
-            }
-        } catch (Exception e) {
-            log.error("Error setting up log stream: {}", e.getMessage());
-            throw e;
-        }
-    }
-
     @Override
     public List<SourceRecord> poll() {
         List<SourceRecord> records = new ArrayList<>();
-        GetLogEventsRequest logEventsRequest = GetLogEventsRequest.builder()
+        FilterLogEventsRequest logEventsRequest = FilterLogEventsRequest.builder()
                 .logGroupName(logGroup)
-                .logStreamName(logStream)
                 .build();
 
         // 오프셋 정보가 있는지 확인
-        Map<String,Object> offset = context.offsetStorageReader().offset(Collections.singletonMap("logStream", logStream));
+        Map<String,Object> offset = context.offsetStorageReader().offset(Collections.singletonMap("logGroup", logGroup));
         if (offset != null) {
             Object lastRecordedOffset = offset.get("timestamp");
             if (lastRecordedOffset!= null && !(lastRecordedOffset instanceof Long)) {
@@ -95,26 +76,25 @@ public class AWSCloudwatchLogSourceTask extends SourceTask {
                 logEventsRequest = logEventsRequest.toBuilder().startTime((Long) lastRecordedOffset).build();
             }
         } else {
-            log.debug("No offset found, starting from the beginning at {}.{}", logGroup, logStream);
-            logEventsRequest = logEventsRequest.toBuilder().startTime(0L).build();
+            log.info("No offset found, starting from the current time {}", logGroup);
+            logEventsRequest = logEventsRequest.toBuilder().startTime(System.currentTimeMillis() - 1000 * 60 * 60 * 24).build();
         }
 
-        GetLogEventsResponse logEventsResponse = cloudWatchLogsClient.getLogEvents(logEventsRequest);
-        Map<String, String> sourcePartition = Collections.singletonMap("logStream", logStream);
+        FilterLogEventsResponse logEventsResponse = cloudWatchLogsClient.filterLogEvents(logEventsRequest);
+        Map<String, String> sourcePartition = Collections.singletonMap("logGroup", logGroup);
 
-        for (OutputLogEvent event : logEventsResponse.events()) {
+        for (FilteredLogEvent event : logEventsResponse.events()) {
             String eventMessage = event.message();
             Map<String, Long> sourceOffset = Map.of("timestamp", event.timestamp());
             SourceRecord record = new SourceRecord(
                     sourcePartition,
                     sourceOffset,
-                    config.getString(AWSCloudwatchLogSourceConfig.AWS_CLOUDWATCH_LOG_GROUP).replace("/","-").substring(1),
+                    topicName,
                     Schema.STRING_SCHEMA,
                     eventMessage
             );
             records.add(record);
         }
-
         return records;
     }
 
@@ -125,26 +105,5 @@ public class AWSCloudwatchLogSourceTask extends SourceTask {
         if (cloudWatchLogsClient != null) {
             cloudWatchLogsClient.close();
         }
-    }
-
-    private String getLatestLogStream() {
-        DescribeLogStreamsRequest request = DescribeLogStreamsRequest.builder()
-                .logGroupName(logGroup)
-                .orderBy("LastEventTime")
-                .descending(true)
-                .limit(1)
-                .build();
-
-        DescribeLogStreamsResponse response = cloudWatchLogsClient.describeLogStreams(request);
-
-        if (!response.logStreams().isEmpty()) {
-            LogStream latestLogStream = response.logStreams().get(0);
-            lastEventTimestamp = latestLogStream.lastEventTimestamp();
-            return latestLogStream.logStreamName();
-        } else {
-            log.error("No log streams found for the specified log group.");
-            throw new RuntimeException("No log streams found.");
-        }
-
     }
 }


### PR DESCRIPTION
- LogStream 기준으로 처리할 경우, 다음 로그 스트림으로 넘어가는 시점을 판단하기에 어려움이 있어, 시간 기반으로 변경
- 관련 메서드 삭제
  - getLogStream
  - setupLogStream
  - exactlyOnceSupport  - Exactly-once를 지원할 수 있는 적합한 키가 존재하지 않아 제거

